### PR TITLE
feat: add apple/swift-log

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "33d9805f3cbf8c2f65486d559097116abb726042c60db7a625fd1e24f35d5f6f",
+  "originHash" : "5a914984abdda40917b99d0ad7096bd73088958ea4736bc227dd95043b602428",
   "pins" : [
     {
       "identity" : "azookeykanakanjiconverter",
@@ -52,6 +52,15 @@
       "state" : {
         "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
         "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
+        "version" : "1.6.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", revision: "2cde22d3e2dd67244f7b095e092f23892dd4d566", traits: ["Zenzai"]),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0")
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -34,7 +35,8 @@ let package = Package(
                 .product(name: "KanaKanjiConverterModuleWithDefaultDictionary", package: "AzooKeyKanaKanjiConverter"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
-                .product(name: "ArgumentParser", package: "swift-argument-parser")
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "Logging", package: "swift-log"),
             ],
             resources: [
                 .copy("zenz-v1.gguf")

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -3,8 +3,10 @@ import ArgumentParser
 import NIOCore
 import NIOPosix
 import KanaKanjiConverterModuleWithDefaultDictionary
+import Logging
 
-// TODO: stderrに出力を分けたい
+LoggingSystem.bootstrap(StreamLogHandler.standardError)
+let logger = Logger(label: "io.github.gitusp.azoo-key-skkserv")
 
 let version = "0.1.0"
 
@@ -48,7 +50,7 @@ struct AzooKeySkkserv: ParsableCommand {
             do {
                 try await runServer(context: self)
             } catch let error {
-                print("An error occured: \(error)")
+                logger.error("An error occurred: \(error)")
                 abort()
             }
         }
@@ -102,6 +104,7 @@ func runServer(context: AzooKeySkkserv) async throws {
                 )
             }
         }
+    logger.notice("Server started on port \(context.port) with incoming charset \(context.incomingCharset.rawValue).")
 
     try await withThrowingDiscardingTaskGroup { group in
         try await server.executeThenClose { clients in
@@ -149,7 +152,7 @@ func handleClient(context: AzooKeySkkserv, converter: KanaKanjiConverter, client
                 case "4":
                     try await outbound.write(allocator.buffer(string: "4\n" ))
                 default:
-                    break;
+                    break
                 }
             }
         }


### PR DESCRIPTION
※不要そうならクローズしても大丈夫です。

`TODO: stderrに出力を分けたい` というコメントがあったので、https://github.com/apple/swift-log によるロギングを導入します。
特にログフォーマットは整えてないため、今の状態では次のようなログが起動時に出力されます。

`2025-07-06T23:49:30+0900 notice io.github.gitusp.azoo-key-skkserv : [azoo_key_skkserv] Server started on port 1178 with incoming charset UTF-8.`

macOS向けのGUIアプリケーションにするときにはConsole.appに記録されるようにしようかなと思っています。
chrisaljoudi/swift-log-oslog というのが使えそう
https://github.com/apple/swift-log?tab=readme-ov-file#available-logging-backends-for-applications
パフォーマンス面ではOSLogを直接使ったほうがいいとありますが、macOS/Linuxで共通インターフェイスをもつLoggerとしてはapple/swift-logがいいのかな? と思っています。