### PR TITLE
feat: support server stop by Task.cancel()

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -78,6 +78,26 @@ enum IncomingCharset: String, ExpressibleByArgument, CaseIterable {
     }
 }
 
+/**
+ * SKKServを起動する。
+ *
+ * Taskの中でrunServerを実行しTask.cancel()を呼び出すことでサーバーを停止できる。
+ *
+ * ```swift
+ * // SKKServを起動
+ * let task = Task {
+ *     do {
+ *         try await runServer(context: context)
+ *     } catch is CancellationError {
+ *         // タスクがキャンセルされたとき
+ *     } catch {
+ *         // その他のエラーが発生したとき
+ *     }
+ * }
+ * // SKKServを停止
+ * task.cancel()
+ * ```
+ */
 func runServer(context: AzooKeySkkserv) async throws {
     // コンバータ初期化
     let converter = await KanaKanjiConverter()
@@ -107,12 +127,17 @@ func runServer(context: AzooKeySkkserv) async throws {
     logger.notice("Server started on port \(context.port) with incoming charset \(context.incomingCharset.rawValue).")
 
     try await withThrowingDiscardingTaskGroup { group in
-        try await server.executeThenClose { clients in
-            for try await client in clients {
-                group.addTask {
-                    await handleClient(context: context, converter: converter, client: client)
+        try await withTaskCancellationHandler {
+            try await server.executeThenClose { clients in
+                for try await client in clients {
+                    group.addTask {
+                        await handleClient(context: context, converter: converter, client: client)
+                    }
                 }
             }
+        } onCancel: {
+            logger.notice("Server is shutting down.")
+            server.channel.close(mode: .input, promise: nil)
         }
     }
 }

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -174,13 +174,14 @@ func handleClient(context: AzooKeySkkserv, converter: KanaKanjiConverter, client
                                 + "/\n"
                         try await outbound.write(allocator.buffer(string: content))
                     case "2":
-                        try await outbound.write(allocator.buffer(string: "azoo-key-skkserve/" + version + " "))
+                        try await outbound.write(allocator.buffer(string: "azoo-key-skkserv/" + version + " "))
                     case "3":
                         let host = Host.current().localizedName ?? ""
-                        try await outbound.write(allocator.buffer(string: host + "/127.0.0.1:" + String(context.port) + "/ "))
+                        try await outbound.write(allocator.buffer(string: "\(host)/127.0.0.1:\(context.port)/ "))
                     case "4":
                         try await outbound.write(allocator.buffer(string: "4\n" ))
                     default:
+                        logger.warning("Unsupported opcode: \(opcode)")
                         break
                     }
                 }


### PR DESCRIPTION
SKKServをTask内で開始したあとにTask.cancel()で停止できるようにします。
用途としてはGUI版から起動したあとで停止するための機能と考えています。
それとおまけで細かいリファクタ的な修正を入れています。

SKKServ側で停止が要求されたことを検知するために、Taskの[`withTaskCancellationHandler(operation:onCancel:isolation:)`](withTaskCancellationHandler(operation:onCancel:isolation:))を使用しています。

ちょっと今のコードでサーバー停止を試すのは難しいんですが、実際にGUIアプリからSKKServを止めたり再開したりできています。
Start Serverボタンで起動するとメンバーのserverTaskに保持しておき、Stop ServerボタンでTaskのキャンセルを行います。

```swift
import SwiftUI
import Core

struct ContentView: View {
    @State var host: String = "127.0.0.1"
    @State var port: Int = 1178
    @State var incomingCharset: IncomingCharset = .utf8
    @State var running: Bool = false
    @State private var serverTask: Task<Void, Error>? = nil
    @State private var showingAlert: Bool = false
    @State private var errorMessage: String = ""
    let server = SKKServer()
    private let formatter: NumberFormatter = {
        let formatter = NumberFormatter()
        formatter.minimum = 1
        formatter.maximum = 65535
        return formatter
    }()

    var body: some View {
        VStack {
            Form {
                TextField("Host", text: $host, prompt: Text("127.0.0.1"))
                    .disabled(running)
                TextField("Port", value: $port, formatter: formatter, prompt: Text("1178"))
                    .disabled(running)
                Picker("Incoming Charset", selection: $incomingCharset) {
                    ForEach(IncomingCharset.allCases, id: \.self) { charset in
                        Text(charset.rawValue).tag(charset)
                    }
                }
                .disabled(running)
                Button("Start Server") {
                    running = true
                    serverTask = Task {
                        do {
                            try await server.run(host: host, port: port, incomingCharset: incomingCharset.stringEncoding)
                        } catch is CancellationError {
                            // キャンセルが正常に完了した
                            print("Server task was cancelled.")
                        } catch {
                            // キャンセル以外のエラーが発生した場合はアラートを表示する
                            print("Server task error: \(error)")
                            errorMessage = error.localizedDescription
                            showingAlert = true
                        }
                        running = false
                        serverTask = nil
                    }
                }
                .disabled(running)
                Button("Stop Server") {
                    serverTask?.cancel()
                }
                .disabled(!running)
            }
        }
        .padding()
        .onAppear {
            server.prepare()
        }
        .alert("Error", isPresented: $showingAlert) {
            Button("OK") { }
        } message: {
            Text(errorMessage)
        }
    }
}
```