### PR TITLE
feat: macOS SwiftUI App

### DIFF
--- a/App/azoo-key-skkserv.xcodeproj/project.pbxproj
+++ b/App/azoo-key-skkserv.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		CE4023BC2E20149F0034FB8F /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = CE4023BB2E20149F0034FB8F /* Core */; };
+		CEA253902E212F2500618E64 /* LoggingOSLog in Frameworks */ = {isa = PBXBuildFile; productRef = CEA2538F2E212F2500618E64 /* LoggingOSLog */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE4023BC2E20149F0034FB8F /* Core in Frameworks */,
+				CEA253902E212F2500618E64 /* LoggingOSLog in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -71,6 +73,7 @@
 			name = "azoo-key-skkserv";
 			packageProductDependencies = (
 				CE4023BB2E20149F0034FB8F /* Core */,
+				CEA2538F2E212F2500618E64 /* LoggingOSLog */,
 			);
 			productName = "azoo-key-skkserv";
 			productReference = CE4023A42E2013BF0034FB8F /* azoo-key-skkserv.app */;
@@ -102,6 +105,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				CE4023BA2E20149F0034FB8F /* XCLocalSwiftPackageReference "../Core" */,
+				CEA2538E2E212F2500618E64 /* XCRemoteSwiftPackageReference "swift-log-oslog" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = CE4023A52E2013BF0034FB8F /* Products */;
@@ -336,10 +340,26 @@
 		};
 /* End XCLocalSwiftPackageReference section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		CEA2538E2E212F2500618E64 /* XCRemoteSwiftPackageReference "swift-log-oslog" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/chrisaljoudi/swift-log-oslog.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		CE4023BB2E20149F0034FB8F /* Core */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Core;
+		};
+		CEA2538F2E212F2500618E64 /* LoggingOSLog */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CEA2538E2E212F2500618E64 /* XCRemoteSwiftPackageReference "swift-log-oslog" */;
+			productName = LoggingOSLog;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/App/azoo-key-skkserv.xcodeproj/project.pbxproj
+++ b/App/azoo-key-skkserv.xcodeproj/project.pbxproj
@@ -1,0 +1,320 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXFileReference section */
+		CE4023A42E2013BF0034FB8F /* azoo-key-skkserv.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "azoo-key-skkserv.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		CE4023A62E2013BF0034FB8F /* azoo-key-skkserv */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "azoo-key-skkserv";
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		CE4023A12E2013BF0034FB8F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		CE40239B2E2013BF0034FB8F = {
+			isa = PBXGroup;
+			children = (
+				CE4023A62E2013BF0034FB8F /* azoo-key-skkserv */,
+				CE4023A52E2013BF0034FB8F /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		CE4023A52E2013BF0034FB8F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CE4023A42E2013BF0034FB8F /* azoo-key-skkserv.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		CE4023A32E2013BF0034FB8F /* azoo-key-skkserv */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CE4023B02E2013C00034FB8F /* Build configuration list for PBXNativeTarget "azoo-key-skkserv" */;
+			buildPhases = (
+				CE4023A02E2013BF0034FB8F /* Sources */,
+				CE4023A12E2013BF0034FB8F /* Frameworks */,
+				CE4023A22E2013BF0034FB8F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				CE4023A62E2013BF0034FB8F /* azoo-key-skkserv */,
+			);
+			name = "azoo-key-skkserv";
+			packageProductDependencies = (
+			);
+			productName = "azoo-key-skkserv";
+			productReference = CE4023A42E2013BF0034FB8F /* azoo-key-skkserv.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CE40239C2E2013BF0034FB8F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1640;
+				LastUpgradeCheck = 1640;
+				TargetAttributes = {
+					CE4023A32E2013BF0034FB8F = {
+						CreatedOnToolsVersion = 16.4;
+					};
+				};
+			};
+			buildConfigurationList = CE40239F2E2013BF0034FB8F /* Build configuration list for PBXProject "azoo-key-skkserv" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CE40239B2E2013BF0034FB8F;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = CE4023A52E2013BF0034FB8F /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CE4023A32E2013BF0034FB8F /* azoo-key-skkserv */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CE4023A22E2013BF0034FB8F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CE4023A02E2013BF0034FB8F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		CE4023AE2E2013C00034FB8F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.5;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		CE4023AF2E2013C00034FB8F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.5;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		CE4023B12E2013C00034FB8F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "azoo-key-skkserv/azoo_key_skkserv.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.github.gitusp.azoo-key-skkserv";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		CE4023B22E2013C00034FB8F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "azoo-key-skkserv/azoo_key_skkserv.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.github.gitusp.azoo-key-skkserv";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CE40239F2E2013BF0034FB8F /* Build configuration list for PBXProject "azoo-key-skkserv" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CE4023AE2E2013C00034FB8F /* Debug */,
+				CE4023AF2E2013C00034FB8F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CE4023B02E2013C00034FB8F /* Build configuration list for PBXNativeTarget "azoo-key-skkserv" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CE4023B12E2013C00034FB8F /* Debug */,
+				CE4023B22E2013C00034FB8F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = CE40239C2E2013BF0034FB8F /* Project object */;
+}

--- a/App/azoo-key-skkserv.xcodeproj/project.pbxproj
+++ b/App/azoo-key-skkserv.xcodeproj/project.pbxproj
@@ -259,7 +259,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.github.gitusp.azoo-key-skkserv";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -284,7 +285,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.github.gitusp.azoo-key-skkserv";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/App/azoo-key-skkserv.xcodeproj/project.pbxproj
+++ b/App/azoo-key-skkserv.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_INTEROP_MODE = objcxx;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -300,6 +301,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_INTEROP_MODE = objcxx;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/App/azoo-key-skkserv.xcodeproj/project.pbxproj
+++ b/App/azoo-key-skkserv.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		CE4023BC2E20149F0034FB8F /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = CE4023BB2E20149F0034FB8F /* Core */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		CE4023A42E2013BF0034FB8F /* azoo-key-skkserv.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "azoo-key-skkserv.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -23,6 +27,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE4023BC2E20149F0034FB8F /* Core in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -65,6 +70,7 @@
 			);
 			name = "azoo-key-skkserv";
 			packageProductDependencies = (
+				CE4023BB2E20149F0034FB8F /* Core */,
 			);
 			productName = "azoo-key-skkserv";
 			productReference = CE4023A42E2013BF0034FB8F /* azoo-key-skkserv.app */;
@@ -94,6 +100,9 @@
 			);
 			mainGroup = CE40239B2E2013BF0034FB8F;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				CE4023BA2E20149F0034FB8F /* XCLocalSwiftPackageReference "../Core" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = CE4023A52E2013BF0034FB8F /* Products */;
 			projectDirPath = "";
@@ -317,6 +326,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		CE4023BA2E20149F0034FB8F /* XCLocalSwiftPackageReference "../Core" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../Core;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		CE4023BB2E20149F0034FB8F /* Core */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Core;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = CE40239C2E2013BF0034FB8F /* Project object */;
 }

--- a/App/azoo-key-skkserv.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/App/azoo-key-skkserv.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/App/azoo-key-skkserv.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/azoo-key-skkserv.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "41595dac718ec2cf6a532474f2a0c1e3f0b61cc57c32d8523403d0ff8c9d99b8",
+  "originHash" : "60944506946b56924334c43cb5d5e16fa1c62f231cef05d7d8cf8062f62c5e81",
   "pins" : [
     {
       "identity" : "azookeykanakanjiconverter",
@@ -52,6 +52,15 @@
       "state" : {
         "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
         "version" : "1.6.3"
+      }
+    },
+    {
+      "identity" : "swift-log-oslog",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/chrisaljoudi/swift-log-oslog.git",
+      "state" : {
+        "revision" : "176d41d46429e79c806333025b226e0c50a0c602",
+        "version" : "0.2.2"
       }
     },
     {

--- a/App/azoo-key-skkserv.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/azoo-key-skkserv.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,103 @@
+{
+  "originHash" : "41595dac718ec2cf6a532474f2a0c1e3f0b61cc57c32d8523403d0ff8c9d99b8",
+  "pins" : [
+    {
+      "identity" : "azookeykanakanjiconverter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/azooKey/AzooKeyKanaKanjiConverter",
+      "state" : {
+        "revision" : "2cde22d3e2dd67244f7b095e092f23892dd4d566"
+      }
+    },
+    {
+      "identity" : "jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/johnmai-dev/Jinja",
+      "state" : {
+        "revision" : "31c4dd39bcdc07eaa42a384bdc88ea599022b800",
+        "version" : "1.1.2"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
+        "version" : "1.6.3"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "ad6b5f17270a7008f60d35ec5378e6144a575162",
+        "version" : "2.84.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-tokenizers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ensan-hcl/swift-tokenizers",
+      "state" : {
+        "branch" : "feat/minimum",
+        "revision" : "407e51806c0c3354a9045f23859ed1704114e514"
+      }
+    },
+    {
+      "identity" : "swiftymarisa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ensan-hcl/SwiftyMarisa",
+      "state" : {
+        "revision" : "6e145aef5583aac96dd7ff8f9fbb9944d893128e"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/App/azoo-key-skkserv/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/App/azoo-key-skkserv/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/App/azoo-key-skkserv/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/App/azoo-key-skkserv/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/App/azoo-key-skkserv/Assets.xcassets/Contents.json
+++ b/App/azoo-key-skkserv/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/App/azoo-key-skkserv/ContentView.swift
+++ b/App/azoo-key-skkserv/ContentView.swift
@@ -9,16 +9,21 @@ struct ContentView: View {
     @State var port: Int = 1178
     @State var incomingCharset: IncomingCharset = .utf8
     @State var running: Bool = false
-    @State private var serverTask: Task<Void, Error>? = nil
-    @State private var showingAlert: Bool = false
-    @State private var errorMessage: String = ""
-    let server = SKKServer(version: "0.1.0", logger: Logger(label: "io.github.gitusp.azoo-key-skkserv"))
-    private let formatter: NumberFormatter = {
+    @State var serverTask: Task<Void, Error>? = nil
+    @State var showingAlert: Bool = false
+    @State var errorMessage: String = ""
+    let logger = Logger(label: "io.github.gitusp.azoo-key-skkserv")
+    let server: SKKServer
+    let formatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.minimum = 1
         formatter.maximum = 65535
         return formatter
     }()
+
+    init() {
+        server = SKKServer(version: "0.1.0", logger: logger)
+    }
 
     var body: some View {
         VStack {
@@ -40,10 +45,10 @@ struct ContentView: View {
                             try await server.run(host: host, port: port, incomingCharset: incomingCharset.stringEncoding)
                         } catch is CancellationError {
                             // キャンセルが正常に完了した
-                            print("Server task was cancelled.")
+                            logger.notice("Server task was cancelled.")
                         } catch {
                             // キャンセル以外のエラーが発生した場合はアラートを表示する
-                            print("Server task error: \(error)")
+                            logger.error("Server task error: \(error)")
                             errorMessage = error.localizedDescription
                             showingAlert = true
                         }

--- a/App/azoo-key-skkserv/ContentView.swift
+++ b/App/azoo-key-skkserv/ContentView.swift
@@ -1,19 +1,76 @@
 // SPDX-License-Identifier: MIT
 
 import SwiftUI
+import Core
+import Logging
 
 struct ContentView: View {
+    @State var host: String = "127.0.0.1"
+    @State var port: Int = 1178
+    @State var incomingCharset: IncomingCharset = .utf8
+    @State var running: Bool = false
+    @State private var serverTask: Task<Void, Error>? = nil
+    @State private var showingAlert: Bool = false
+    @State private var errorMessage: String = ""
+    let server = SKKServer(version: "0.1.0", logger: Logger(label: "io.github.gitusp.azoo-key-skkserv"))
+    private let formatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.minimum = 1
+        formatter.maximum = 65535
+        return formatter
+    }()
+
     var body: some View {
         VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+            Form {
+                TextField("Host", text: $host, prompt: Text("127.0.0.1"))
+                    .disabled(running)
+                TextField("Port", value: $port, formatter: formatter, prompt: Text("1178"))
+                    .disabled(running)
+                Picker("Incoming Charset", selection: $incomingCharset) {
+                    ForEach(IncomingCharset.allCases, id: \.self) { charset in
+                        Text(charset.rawValue).tag(charset)
+                    }
+                }
+                .disabled(running)
+                Button("Start Server") {
+                    running = true
+                    serverTask = Task {
+                        do {
+                            try await server.run(host: host, port: port, incomingCharset: incomingCharset.stringEncoding)
+                        } catch is CancellationError {
+                            // キャンセルが正常に完了した
+                            print("Server task was cancelled.")
+                        } catch {
+                            // キャンセル以外のエラーが発生した場合はアラートを表示する
+                            print("Server task error: \(error)")
+                            errorMessage = error.localizedDescription
+                            showingAlert = true
+                        }
+                        running = false
+                        serverTask = nil
+                    }
+                }
+                .disabled(running)
+                Button("Stop Server") {
+                    serverTask?.cancel()
+                }
+                .disabled(!running)
+            }
         }
         .padding()
+        .onAppear {
+            server.prepare()
+        }
+        .alert("Error", isPresented: $showingAlert) {
+            Button("OK") { }
+        } message: {
+            Text(errorMessage)
+        }
     }
 }
 
 #Preview {
     ContentView()
+        .frame(width: 320, height: 180)
 }

--- a/App/azoo-key-skkserv/ContentView.swift
+++ b/App/azoo-key-skkserv/ContentView.swift
@@ -1,0 +1,24 @@
+//
+//  ContentView.swift
+//  azoo-key-skkserv
+//
+//  Created by mtgto on 2025/07/11.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/App/azoo-key-skkserv/ContentView.swift
+++ b/App/azoo-key-skkserv/ContentView.swift
@@ -1,9 +1,4 @@
-//
-//  ContentView.swift
-//  azoo-key-skkserv
-//
-//  Created by mtgto on 2025/07/11.
-//
+// SPDX-License-Identifier: MIT
 
 import SwiftUI
 

--- a/App/azoo-key-skkserv/IncomingCharset.swift
+++ b/App/azoo-key-skkserv/IncomingCharset.swift
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+// 文字コードオプション
+public enum IncomingCharset: String, CaseIterable {
+    case utf8 = "UTF-8"
+    case eucjp = "EUC-JP"
+
+    var stringEncoding: String.Encoding {
+        switch self {
+            case .utf8: return .utf8
+            case .eucjp: return .japaneseEUC
+        }
+    }
+}

--- a/App/azoo-key-skkserv/azoo_key_skkserv.entitlements
+++ b/App/azoo-key-skkserv/azoo_key_skkserv.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+</dict>
+</plist>

--- a/App/azoo-key-skkserv/azoo_key_skkserv.entitlements
+++ b/App/azoo-key-skkserv/azoo_key_skkserv.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>
 </plist>

--- a/App/azoo-key-skkserv/azoo_key_skkservApp.swift
+++ b/App/azoo-key-skkserv/azoo_key_skkservApp.swift
@@ -1,12 +1,19 @@
 // SPDX-License-Identifier: MIT
 
 import SwiftUI
+import Logging
+import LoggingOSLog
 
 @main
 struct azoo_key_skkservApp: App {
+    init() {
+        LoggingSystem.bootstrap(LoggingOSLog.init)
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .frame(width: 320, height: 180)
         }
     }
 }

--- a/App/azoo-key-skkserv/azoo_key_skkservApp.swift
+++ b/App/azoo-key-skkserv/azoo_key_skkservApp.swift
@@ -1,0 +1,17 @@
+//
+//  azoo_key_skkservApp.swift
+//  azoo-key-skkserv
+//
+//  Created by mtgto on 2025/07/11.
+//
+
+import SwiftUI
+
+@main
+struct azoo_key_skkservApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/App/azoo-key-skkserv/azoo_key_skkservApp.swift
+++ b/App/azoo-key-skkserv/azoo_key_skkservApp.swift
@@ -1,9 +1,4 @@
-//
-//  azoo_key_skkservApp.swift
-//  azoo-key-skkserv
-//
-//  Created by mtgto on 2025/07/11.
-//
+// SPDX-License-Identifier: MIT
 
 import SwiftUI
 

--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -1,0 +1,44 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Core",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "Core",
+            targets: ["Core"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", revision: "2cde22d3e2dd67244f7b095e092f23892dd4d566", traits: ["Zenzai"]),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "Core",
+            dependencies: [
+                .product(name: "KanaKanjiConverterModuleWithDefaultDictionary", package: "AzooKeyKanaKanjiConverter"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
+                .product(name: "Logging", package: "swift-log"),
+            ],
+            resources: [
+                .copy("zenz-v1.gguf")
+            ],
+            swiftSettings: [
+                .interoperabilityMode(.Cxx)
+            ],
+        ),
+        .testTarget(
+            name: "CoreTests",
+            dependencies: ["Core"]
+        ),
+    ]
+)

--- a/Core/Sources/Core/SKKServer.swift
+++ b/Core/Sources/Core/SKKServer.swift
@@ -88,17 +88,12 @@ import Logging
         logger.notice("Server started on port \(port) with incoming charset \(incomingCharset.rawValue).")
 
         try await withThrowingDiscardingTaskGroup { group in
-            try await withTaskCancellationHandler {
-                try await server.executeThenClose { clients in
-                    for try await client in clients {
-                        group.addTask {
-                            await handleClient(client: client, host: host, port: port, incomingCharset: incomingCharset)
-                        }
+            try await server.executeThenClose { clients in
+                for try await client in clients {
+                    group.addTask {
+                        await handleClient(client: client, host: host, port: port, incomingCharset: incomingCharset)
                     }
                 }
-            } onCancel: {
-                logger.notice("Server is shutting down.")
-                server.channel.close(mode: .input, promise: nil)
             }
         }
     }

--- a/Core/Sources/Core/SKKServer.swift
+++ b/Core/Sources/Core/SKKServer.swift
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import NIOCore
+import NIOPosix
+import KanaKanjiConverterModuleWithDefaultDictionary
+import Logging
+
+@MainActor public struct SKKServer {
+    let allocator = ByteBufferAllocator()
+    let convertOption: ConvertRequestOptions
+    let converter: KanaKanjiConverter
+    let version: String
+    let logger: Logger
+
+    public init(version: String, logger: Logger) {
+        self.version = version
+        self.logger = logger
+        convertOption = ConvertRequestOptions.withDefaultDictionary(
+            // 日本語予測変換
+            requireJapanesePrediction: false,
+            // 英語予測変換
+            requireEnglishPrediction: false,
+            // 入力言語
+            keyboardLanguage: .ja_JP,
+            // 学習タイプ
+            learningType: .nothing,
+            // TODO: 扱いについて検討
+            memoryDirectoryURL: URL(fileURLWithPath: ""),
+            sharedContainerURL: URL(fileURLWithPath: ""),
+            zenzaiMode: .on(
+                weight: Bundle.module.url(forResource: "zenz-v1", withExtension: "gguf")!,
+                inferenceLimit: 1,
+                personalizationMode: nil,
+                versionDependentMode: .v1
+            ),
+            metadata: .init(versionString: version)
+        )
+        // コンバータ初期化
+        converter = KanaKanjiConverter(dicdataStore: DicdataStore(convertRequestOptions: convertOption))
+    }
+
+    public func prepare() {
+        // HACK: ダミーリクエストを送信してモデルを先読みしておく
+        var dummyComposingText = ComposingText()
+        dummyComposingText.insertAtCursorPosition("もでるさきよみ", inputStyle: .direct)
+        _ = converter.requestCandidates(dummyComposingText, options: convertOption)
+    }
+
+    /**
+      * SKKServを起動する。
+      *
+      * Taskの中でrunServerを実行しTask.cancel()を呼び出すことでサーバーを停止できる。
+      *
+      * ```swift
+      * // SKKServを起動
+      * let task = Task {
+      *     do {
+      *         try await run()
+      *     } catch is CancellationError {
+      *         // タスクがキャンセルされたとき
+      *     } catch {
+      *         // その他のエラーが発生したとき
+      *     }
+      * }
+      * // SKKServを停止
+      * task.cancel()
+      * ```
+      */
+    public func run(host: String = "127.0.0.1", port: Int = 1178, incomingCharset: String.Encoding = .utf8) async throws {
+        // こちらのガイドを参考に実装した。
+        // https://swiftonserver.com/using-swiftnio-channels/
+        let server = try await ServerBootstrap(group: NIOSingletons.posixEventLoopGroup)
+            .bind(
+                host: host,
+                port: port
+            ) { channel in
+                channel.eventLoop.makeCompletedFuture {
+                    return try NIOAsyncChannel(
+                        wrappingChannelSynchronously: channel,
+                        configuration: NIOAsyncChannel.Configuration(
+                            inboundType: ByteBuffer.self,
+                            outboundType: ByteBuffer.self
+                        )
+                    )
+                }
+            }
+        logger.notice("Server started on port \(port) with incoming charset \(incomingCharset.rawValue).")
+
+        try await withThrowingDiscardingTaskGroup { group in
+            try await withTaskCancellationHandler {
+                try await server.executeThenClose { clients in
+                    for try await client in clients {
+                        group.addTask {
+                            await handleClient(client: client, host: host, port: port, incomingCharset: incomingCharset)
+                        }
+                    }
+                }
+            } onCancel: {
+                logger.notice("Server is shutting down.")
+                server.channel.close(mode: .input, promise: nil)
+            }
+        }
+    }
+
+    func handleClient(client: NIOAsyncChannel<ByteBuffer, ByteBuffer>, host: String, port: Int, incomingCharset: String.Encoding) async {
+        // クライアントが先にソケットを閉じている状態でソケットへの書き込みを行ったりすると例外が発生し、
+        // そのあとの接続でinboundMessagesからメッセージが取得できなくなってしまう。
+        // それを防ぐため例外をキャッチする必要がある。
+        do {
+            try await client.executeThenClose { inboundMessages, outbound in
+                for try await inboundMessage in inboundMessages {
+                    if let bytes = inboundMessage.getBytes(at: 0, length: inboundMessage.readableBytes),
+                       let message = String(bytes: bytes, encoding: incomingCharset) {
+                        let opcode = message.prefix(1)
+
+                        switch (opcode) {
+                        case "0":
+                            return
+                        case "1":
+                            let yomi = String(message.suffix(message.count - 1))
+                                .trimmingCharacters(in: .whitespacesAndNewlines)
+                                .replacing(/([ぁ-ん])[a-z]$/) { matches in matches.1 }
+                            var composingText = ComposingText()
+                            composingText.insertAtCursorPosition(yomi, inputStyle: .direct)
+                            let results = converter.requestCandidates(composingText, options: convertOption)
+                            let content = results.mainResults.count == 0
+                            ? "4\n"
+                            : "1/"
+                            + results.mainResults
+                            // 読み全文に対応するもの以外・読みと完全一致するものは除去
+                                .filter({ result in result.correspondingCount == yomi.count && result.text != yomi })
+                                .map({ result in result.text })
+                                .joined(by: "/")
+                            + "/\n"
+                            try await outbound.write(allocator.buffer(string: content))
+                        case "2":
+                            try await outbound.write(allocator.buffer(string: "azoo-key-skkserv/" + version + " "))
+                        case "3":
+                            let hostname = Host.current().localizedName ?? ""
+                            try await outbound.write(allocator.buffer(string: "\(hostname)/\(host):\(port) "))
+                        case "4":
+                            try await outbound.write(allocator.buffer(string: "4\n" ))
+                        default:
+                            logger.warning("Unsupported opcode: \(opcode)")
+                            break
+                        }
+                    }
+                }
+            }
+            logger.notice("Connection is closed")
+        } catch {
+            logger.warning("Hit error: \(error)")
+        }
+    }
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5a914984abdda40917b99d0ad7096bd73088958ea4736bc227dd95043b602428",
+  "originHash" : "8fb2c610e34afa6f4d8182e608a47be798722003ae5c964bbeae228403e08f06",
   "pins" : [
     {
       "identity" : "azookeykanakanjiconverter",
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/johnmai-dev/Jinja",
       "state" : {
-        "revision" : "bbddb92fc51ae420b87300298370fd1dfc308f73",
-        "version" : "1.1.1"
+        "revision" : "31c4dd39bcdc07eaa42a384bdc88ea599022b800",
+        "version" : "1.1.2"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
-        "version" : "1.2.0"
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
-        "version" : "1.1.4"
+        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
+        "version" : "1.2.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "6e17bc946821e550b88d22fd964423f70f1ce42d",
-        "version" : "2.82.0"
+        "revision" : "ad6b5f17270a7008f60d35ec5378e6144a575162",
+        "version" : "2.84.0"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "a34201439c74b53f0fd71ef11741af7e7caf01e1",
-        "version" : "1.4.2"
+        "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
+        "version" : "1.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,8 @@ let package = Package(
         .macOS(.v14)
     ],
     dependencies: [
-        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", revision: "2cde22d3e2dd67244f7b095e092f23892dd4d566", traits: ["Zenzai"]),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(name: "Core", path: "./Core"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -32,14 +30,8 @@ let package = Package(
         .executableTarget(
             name: "azoo-key-skkserv",
             dependencies: [
-                .product(name: "KanaKanjiConverterModuleWithDefaultDictionary", package: "AzooKeyKanaKanjiConverter"),
-                .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "NIOPosix", package: "swift-nio"),
+                .product(name: "Core", package: "Core"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "Logging", package: "swift-log"),
-            ],
-            resources: [
-                .copy("zenz-v1.gguf")
             ],
             swiftSettings: [
                 .interoperabilityMode(.Cxx)

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -1,37 +1,12 @@
 import Foundation
 import ArgumentParser
-import NIOCore
-import NIOPosix
-import KanaKanjiConverterModuleWithDefaultDictionary
+import Core
 import Logging
 
 LoggingSystem.bootstrap(StreamLogHandler.standardError)
 let logger = Logger(label: "io.github.gitusp.azoo-key-skkserv")
 
 let version = "0.1.0"
-
-let allocator = ByteBufferAllocator()
-
-let convertOption = ConvertRequestOptions.withDefaultDictionary(
-    // 日本語予測変換
-    requireJapanesePrediction: false,
-    // 英語予測変換 
-    requireEnglishPrediction: false,
-    // 入力言語 
-    keyboardLanguage: .ja_JP,
-    // 学習タイプ 
-    learningType: .nothing, 
-    // TODO: 扱いについて検討
-    memoryDirectoryURL: URL(fileURLWithPath: ""),
-    sharedContainerURL: URL(fileURLWithPath: ""),
-    zenzaiMode: .on(
-        weight: Bundle.module.url(forResource: "zenz-v1", withExtension: "gguf")!,
-        inferenceLimit: 1,
-        personalizationMode: nil,
-        versionDependentMode: .v1
-    ),
-    metadata: .init(versionString: version)
-)
 
 struct AzooKeySkkserv: ParsableCommand {
     static let configuration = CommandConfiguration(
@@ -78,116 +53,8 @@ enum IncomingCharset: String, ExpressibleByArgument, CaseIterable {
     }
 }
 
-/**
- * SKKServを起動する。
- *
- * Taskの中でrunServerを実行しTask.cancel()を呼び出すことでサーバーを停止できる。
- *
- * ```swift
- * // SKKServを起動
- * let task = Task {
- *     do {
- *         try await runServer(context: context)
- *     } catch is CancellationError {
- *         // タスクがキャンセルされたとき
- *     } catch {
- *         // その他のエラーが発生したとき
- *     }
- * }
- * // SKKServを停止
- * task.cancel()
- * ```
- */
 func runServer(context: AzooKeySkkserv) async throws {
-    // コンバータ初期化
-    let converter = await KanaKanjiConverter()
-
-    // HACK: ダミーリクエストを送信してモデルを先読みしておく
-    var dummyComposingText = ComposingText()
-    dummyComposingText.insertAtCursorPosition("もでるさきよみ", inputStyle: .direct)
-    let _ = await converter.requestCandidates(dummyComposingText, options: convertOption)
-
-    // こちらのガイドを参考に実装した。
-    // https://swiftonserver.com/using-swiftnio-channels/
-    let server = try await ServerBootstrap(group: NIOSingletons.posixEventLoopGroup)
-        .bind(
-            host: "127.0.0.1",
-            port: context.port
-        ) { channel in
-            channel.eventLoop.makeCompletedFuture {
-                return try NIOAsyncChannel(
-                    wrappingChannelSynchronously: channel,
-                    configuration: NIOAsyncChannel.Configuration(
-                        inboundType: ByteBuffer.self,
-                        outboundType: ByteBuffer.self
-                    )
-                )
-            }
-        }
-    logger.notice("Server started on port \(context.port) with incoming charset \(context.incomingCharset.rawValue).")
-
-    try await withThrowingDiscardingTaskGroup { group in
-        try await withTaskCancellationHandler {
-            try await server.executeThenClose { clients in
-                for try await client in clients {
-                    group.addTask {
-                        await handleClient(context: context, converter: converter, client: client)
-                    }
-                }
-            }
-        } onCancel: {
-            logger.notice("Server is shutting down.")
-            server.channel.close(mode: .input, promise: nil)
-        }
-    }
-}
-
-func handleClient(context: AzooKeySkkserv, converter: KanaKanjiConverter, client: NIOAsyncChannel<ByteBuffer, ByteBuffer>) async {
-    // クライアントが先にソケットを閉じている状態でソケットへの書き込みを行ったりすると例外が発生し、
-    // そのあとの接続でinboundMessagesからメッセージが取得できなくなってしまう。
-    // それを防ぐため例外をキャッチする必要がある。
-    do {
-        try await client.executeThenClose { inboundMessages, outbound in
-            for try await inboundMessage in inboundMessages {
-                if let bytes = inboundMessage.getBytes(at: 0, length: inboundMessage.readableBytes),
-                    let message = String(bytes: bytes, encoding: context.incomingCharset.stringEncoding) {
-                    let opcode = message.prefix(1)
-
-                    switch (opcode) {
-                    case "0":
-                        return
-                    case "1":
-                        let yomi = String(message.suffix(message.count - 1))
-                            .trimmingCharacters(in: .whitespacesAndNewlines)
-                            .replacing(/([ぁ-ん])[a-z]$/) { matches in matches.1 }
-                        var composingText = ComposingText()
-                        composingText.insertAtCursorPosition(yomi, inputStyle: .direct)
-                        let results = await converter.requestCandidates(composingText, options: convertOption)
-                        let content = results.mainResults.count == 0
-                            ? "4\n"
-                            : "1/"
-                                + results.mainResults
-                                    // 読み全文に対応するもの以外・読みと完全一致するものは除去
-                                    .filter({ result in result.correspondingCount == yomi.count && result.text != yomi })
-                                    .map({ result in result.text })
-                                    .joined(by: "/")
-                                + "/\n"
-                        try await outbound.write(allocator.buffer(string: content))
-                    case "2":
-                        try await outbound.write(allocator.buffer(string: "azoo-key-skkserv/" + version + " "))
-                    case "3":
-                        let host = Host.current().localizedName ?? ""
-                        try await outbound.write(allocator.buffer(string: "\(host)/127.0.0.1:\(context.port)/ "))
-                    case "4":
-                        try await outbound.write(allocator.buffer(string: "4\n" ))
-                    default:
-                        logger.warning("Unsupported opcode: \(opcode)")
-                        break
-                    }
-                }
-            }
-        }
-    } catch {
-        logger.warning("Hit error: \(error)")
-    }
+    let server = await SKKServer(version: version, logger: logger)
+    await server.prepare()
+    try await server.run(host: "127.0.0.1", port: context.port, incomingCharset: context.incomingCharset.stringEncoding)
 }


### PR DESCRIPTION
GUI画面をもつmacOSアプリを作れるようにします。
CUIも `swift run` から実行できることは確認していますが、Linuxバイナリについては確認していません。
Bundle Identifierは他の人と絶対に被らないように仮で `io.github.gitusp.azoo-key-skkserv` にしてありますが、 @gitusp さんの好きに決めていただいて結構です。

<img width="320" height="208" alt="image" src="https://github.com/user-attachments/assets/d8e200df-5b6c-48f1-8b73-dc347689b7b3" />

GUIアプリについてはSwift Packageで定義はせずxcodeprojファイルで管理しています。これはSwift Packageでは単一の実行バイナリ (executableTarget) までは作れるのですが、App Bundle形式で作るにはInfo.plistの配置、依存ライブラリをビルドしてFrameworksに配置、などの処理のサポートが標準ではないためです。
(使ったことはないのですが https://github.com/stackotter/swift-bundler を使えばSwift Packageだけでもいけるかもしれません)

GUIとCUIからAzooKeyKanaKanjiConverterとswift-nioを両方使いたいので、共通部分をCoreというSwift Packageとして切り出しています。
GUIとCUIのディレクトリ構造については下記の記事を参考にし、あえてPackage.swiftと同じディレクトリではなくApp/azoo-key-skkserv.xcodeproj のようにサブディレクトリにGUI部分を配置しました。
https://zenn.dev/st43/articles/c758b22130aefe
(Package.swiftと同じところにxcodeprojを置いた状態で同様にCoreパッケージをGUIアプリの依存に入れていたところ、xcodeprojファイル内でCoreパッケージへの依存がビルドを何度かしている間に複数になっていました。ディレクトリを分けたら再現しなくなったようです)

現時点では冒頭のスクリーンショットでもわかるように必要最小限の機能だけ実装しています。

- 実装/対応済み
  - 起動したら表示されるウィンドウでHost, Port, Incoming Charsetを指定してSKKServを起動
  - SKKServを停止
  - ロギングに https://github.com/chrisaljoudi/swift-log-oslog を使用
  - App Sandboxをデフォルト有効化。Network Incoming (Server) のみ可能にしてあります。
- 未実装
  - Host, Port, Incoming CharsetをUserDefaultsに保存して次回起動時に復元する
  - `~/Containers/<Bundle Identifier>/Data/Documents` 内に学習したデータを保存できるようにする ([AzooKeyKanaKanjiConverterの機能](https://github.com/azooKey/AzooKeyKanaKanjiConverter/blob/develop/Docs/learning_data.md))
  - バイナリ配布の仕組みを作る
    - Mac App Store or Appleの公証を通してGitHub Releases配布 (どちらにしてもApple Developer Programの加入が必要)
  - アイコン (どうしましょう…?)
  - おしゃれなUI 😇 