### PR TITLE
feat: add CI script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-14]
-        # os: [macos-14, macos-15, ubuntu-22.04, ubuntu-24.04]
+        os: [macos-15]
+        # os: [macos-15, ubuntu-22.04, ubuntu-24.04]
 
     steps:
     - uses: actions/checkout@v4
-    - if: matrix.os == 'macos-14'
-      run: sudo xcode-select -s '/Applications/Xcode_16.2.app/Contents/Developer'
     - if: matrix.os == 'macos-15'
       run: sudo xcode-select -s '/Applications/Xcode_16.4.app/Contents/Developer'
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04]
-        # os: [macos-15, ubuntu-22.04, ubuntu-24.04]
+        os: [macos-15, ubuntu-24.04]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-15]
+        os: [ubuntu-24.04]
         # os: [macos-15, ubuntu-22.04, ubuntu-24.04]
 
     steps:
     - uses: actions/checkout@v4
     - if: matrix.os == 'macos-15'
       run: sudo xcode-select -s '/Applications/Xcode_16.4.app/Contents/Developer'
-    - name: Run tests
+    - if: startsWith(matrix.os, 'macos')
+      name: Run tests
       run: swift test 2>&1 | xcbeautify
+    - if: startsWith(matrix.os, 'ubuntu')
+      name: Run tests
+      run: swift test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,5 +32,4 @@ jobs:
       name: Run tests
       run: swift test 2>&1 | xcbeautify
     - if: startsWith(matrix.os, 'ubuntu')
-      name: Run tests
-      run: swift test
+      run: LD_LIBRARY_PATH="$PWD/lib/x86_64:$LD_LIBRARY_PATH" swift test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: test
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '*.md'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '*.md'
+
+# bashを使うようにしてpipefailを有効にする
+# https://docs.github.com/ja/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-14]
+        # os: [macos-14, macos-15, ubuntu-22.04, ubuntu-24.04]
+
+    steps:
+    - uses: actions/checkout@v4
+    - if: matrix.os == 'macos-14'
+      run: sudo xcode-select -s '/Applications/Xcode_16.2.app/Contents/Developer'
+    - if: matrix.os == 'macos-15'
+      run: sudo xcode-select -s '/Applications/Xcode_16.4.app/Contents/Developer'
+    - name: Run tests
+      run: swift test 2>&1 | xcbeautify

--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -36,9 +36,5 @@ let package = Package(
                 .interoperabilityMode(.Cxx)
             ],
         ),
-        .testTarget(
-            name: "CoreTests",
-            dependencies: ["Core"]
-        ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -46,6 +46,7 @@ let package = Package(
             swiftSettings: [
                 .interoperabilityMode(.Cxx)
             ],
+            linkerSettings: linkerSettings
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -37,6 +37,15 @@ let package = Package(
                 .interoperabilityMode(.Cxx)
             ],
             linkerSettings: linkerSettings
+        ),
+        .testTarget(
+            name: "CoreTests",
+            dependencies: [
+                .product(name: "Core", package: "Core"),
+            ],
+            swiftSettings: [
+                .interoperabilityMode(.Cxx)
+            ],
         )
     ]
 )

--- a/Tests/CoreTests/SKKServerVersionTest.swift
+++ b/Tests/CoreTests/SKKServerVersionTest.swift
@@ -1,0 +1,125 @@
+import Testing
+import Foundation
+import NIOCore
+import NIOPosix
+import Logging
+@testable import Core
+
+@Suite("SKKServer Version Test")
+struct SKKServerVersionTest {
+
+    @Test("SKKServerに接続し、バージョン情報を取得する")
+    func testSKKServerVersion() async throws {
+        let port = 11780 // テスト用のポート番号
+        let server = await SKKServer(version: "test", logger: Logger(label: "test"))
+        await server.prepare()
+
+        let serverTask = Task {
+            try await server.run(host: "127.0.0.1", port: port, incomingCharset: String.Encoding.utf8)
+        }
+
+        // サーバーが起動するまで少し待つ
+        try await Task.sleep(nanoseconds: 1_000_000_000) // 1秒
+
+        do {
+            let group = NIOSingletons.posixEventLoopGroup
+            let bootstrap = ClientBootstrap(group: group)
+
+            let channel = try await bootstrap.connect(host: "127.0.0.1", port: port) { channel in
+                channel.eventLoop.makeCompletedFuture {
+                    try channel.pipeline.syncOperations.addHandler(SKKServHandler())
+                    return try NIOAsyncChannel(
+                        wrappingChannelSynchronously: channel,
+                        configuration: NIOAsyncChannel.Configuration(
+                            inboundType: String.self,
+                            outboundType: SKKServRequest.self
+                        )
+                    )
+                }
+            }
+
+            try await channel.executeThenClose { inbound, outbound in
+                try await outbound.write(.version)
+                guard let response = try await inbound.first(where: { _ in true }) else {
+                    Issue.record("応答を受信できません")
+                    return
+                }
+                #expect(response == "azoo-key-skkserv/test", "応答が期待されるプレフィックスで始まっていません: \(response)")
+
+                try await outbound.write(.end)
+            }
+        } catch {
+            Issue.record("テスト中にエラーが発生しました: \(error)")
+        }
+
+        // サーバーを停止
+        serverTask.cancel()
+
+        // タスクの完了を待つ
+        do {
+            try await serverTask.value
+        } catch is CancellationError {
+            // キャンセルエラーは期待される
+        }
+    }
+}
+
+enum SKKServRequest {
+    case end // "0"
+    // case candidates(String) // "1<見出し語> "
+    case version // "2"
+    // case host // "3"
+    // case completion // "4<見出し語> "
+
+    var responseDelimiter: UInt8 {
+        switch self {
+        case .end:
+            return 0
+        case .version:
+            return UInt8(ascii: " ")
+        }
+    }
+}
+
+enum SKKServHandlerError: Error {
+    case invalidResponse
+}
+
+private final class SKKServHandler: ChannelDuplexHandler {
+    typealias InboundIn = ByteBuffer
+    typealias InboundOut = String
+    typealias OutboundIn = SKKServRequest
+    typealias OutboundOut = ByteBuffer
+
+    var overflowBuffer : ByteBuffer? = nil
+    var lastRequest: SKKServRequest? = nil
+
+    // MARK: - Reading
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        guard let delimiter = lastRequest?.responseDelimiter else {
+            context.fireErrorCaught(SKKServHandlerError.invalidResponse)
+            return
+        }
+        var buffer = self.unwrapInboundIn(data)
+        let readableBytes = buffer.readableBytesView
+
+        if let index = readableBytes.firstIndex(of: delimiter), let message = buffer.readString(length: index) {
+            context.fireChannelRead(wrapInboundOut(message))
+        }
+    }
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let request = unwrapOutboundIn(data)
+        let allocator = context.channel.allocator
+        var out = allocator.buffer(capacity: 1)
+        switch request {
+        case .end:
+            out.writeString("0")
+        case .version:
+            out.writeString("2")
+            break
+        }
+        lastRequest = request
+        context.write(wrapOutboundOut(out), promise: promise)
+    }
+}


### PR DESCRIPTION
Pull Requestやmainブランチへの修正でGitHub Actionsによるテストを実行できるようにします。
事前に https://github.com/mtgto/azoo-key-skkserv/pull/1 で実験していました。

テスト環境はmacOS 15, Ubuntu 24.04にしました。

- macOS 14は[Xcode 16.2](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode)までしか入っておらず、Swift 6.1のSwift Package Traitsを使っているせいでコンパイルエラーになってしまうようです。そのため除外しています。
- https://github.com/swift-actions/setup-swift でSwift 6.1を入れたらいけるかなと思ったんですが、Xcodeのバージョンとずれているとだめなようであきらめました。

テストコード自体は簡単なもので、SKKServerをテスト内で11780ポートで起動し、接続して"2" (バージョン情報) と "0" (切断) を送るというものです。
時間をみつけて変換候補取得もテスト項目に入れたいと思います。