### PR TITLE
chore: set so_reuseaddr

### DIFF
--- a/Core/Sources/Core/SKKServer.swift
+++ b/Core/Sources/Core/SKKServer.swift
@@ -71,6 +71,7 @@ import Logging
         // こちらのガイドを参考に実装した。
         // https://swiftonserver.com/using-swiftnio-channels/
         let server = try await ServerBootstrap(group: NIOSingletons.posixEventLoopGroup)
+            .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
             .bind(
                 host: host,
                 port: port


### PR DESCRIPTION
bindしたあと、同一プロセスが短期間に複数回bindしようとすると `Address already in use (errno: 48)` で失敗するので、so_reuseaddrオプションを設定します。

> 2025-07-19T15:45:51+0900 error io.github.gitusp.azoo-key-skkserv : [azoo_key_skkserv] An error occurred: bind(descriptor:ptr:bytes:): Address already in use (errno: 48)

参考

- https://www.geekpage.jp/programming/winsock/so_reuseaddr.php
- https://github.com/apple/swift-nio/blob/2.84.0/Sources/NIOTCPEchoServer/Server.swift#L40