### PR TITLE
feat: persiste host, port and incomingCharset using AppStorage

### DIFF
--- a/App/azoo-key-skkserv.xcodeproj/project.pbxproj
+++ b/App/azoo-key-skkserv.xcodeproj/project.pbxproj
@@ -104,8 +104,8 @@
 			mainGroup = CE40239B2E2013BF0034FB8F;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				CE4023BA2E20149F0034FB8F /* XCLocalSwiftPackageReference "../Core" */,
 				CEA2538E2E212F2500618E64 /* XCRemoteSwiftPackageReference "swift-log-oslog" */,
+				CE4023BA2E20149F0034FB8F /* XCLocalSwiftPackageReference "../Core" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = CE4023A52E2013BF0034FB8F /* Products */;
@@ -265,6 +265,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -292,6 +293,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";

--- a/App/azoo-key-skkserv.xcodeproj/project.pbxproj
+++ b/App/azoo-key-skkserv.xcodeproj/project.pbxproj
@@ -280,7 +280,7 @@
 				REGISTER_APP_GROUPS = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_INTEROP_MODE = objcxx;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -308,7 +308,7 @@
 				REGISTER_APP_GROUPS = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_INTEROP_MODE = objcxx;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};

--- a/App/azoo-key-skkserv/ContentView.swift
+++ b/App/azoo-key-skkserv/ContentView.swift
@@ -5,9 +5,9 @@ import Core
 import Logging
 
 struct ContentView: View {
-    @State var host: String = "127.0.0.1"
-    @State var port: Int = 1178
-    @State var incomingCharset: IncomingCharset = .utf8
+    @AppStorage("host") var host: String = "127.0.0.1"
+    @AppStorage("port") var port: Int = 1178
+    @AppStorage("incomingCharset") var incomingCharset: IncomingCharset = .utf8
     @State var running: Bool = false
     @State var serverTask: Task<Void, Error>? = nil
     @State var showingAlert: Bool = false

--- a/App/azoo-key-skkserv/ContentView.swift
+++ b/App/azoo-key-skkserv/ContentView.swift
@@ -13,17 +13,13 @@ struct ContentView: View {
     @State var showingAlert: Bool = false
     @State var errorMessage: String = ""
     let logger = Logger(label: "io.github.gitusp.azoo-key-skkserv")
-    let server: SKKServer
+    @State var server: SKKServer? = nil
     let formatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.minimum = 1
         formatter.maximum = 65535
         return formatter
     }()
-
-    init() {
-        server = SKKServer(version: "0.1.0", logger: logger)
-    }
 
     var body: some View {
         VStack {
@@ -42,7 +38,11 @@ struct ContentView: View {
                     running = true
                     serverTask = Task {
                         do {
-                            try await server.run(host: host, port: port, incomingCharset: incomingCharset.stringEncoding)
+                            if server == nil {
+                                server = SKKServer(version: "0.1.0", logger: logger)
+                                server?.prepare()
+                            }
+                            try await server!.run(host: host, port: port, incomingCharset: incomingCharset.stringEncoding)
                         } catch is CancellationError {
                             // キャンセルが正常に完了した
                             logger.notice("Server task was cancelled.")
@@ -64,9 +64,6 @@ struct ContentView: View {
             }
         }
         .padding()
-        .onAppear {
-            server.prepare()
-        }
         .alert("Error", isPresented: $showingAlert) {
             Button("OK") { }
         } message: {

--- a/App/azoo-key-skkserv/ContentView.swift
+++ b/App/azoo-key-skkserv/ContentView.swift
@@ -8,6 +8,7 @@ struct ContentView: View {
     @AppStorage("host") var host: String = "127.0.0.1"
     @AppStorage("port") var port: Int = 1178
     @AppStorage("incomingCharset") var incomingCharset: IncomingCharset = .utf8
+    @AppStorage("startServerAtLaunch") var startServerAtLaunch: Bool = false
     @State var running: Bool = false
     @State var serverTask: Task<Void, Error>? = nil
     @State var showingAlert: Bool = false
@@ -34,27 +35,9 @@ struct ContentView: View {
                     }
                 }
                 .disabled(running)
+                Toggle("Start Server At Launch", isOn: $startServerAtLaunch)
                 Button("Start Server") {
-                    running = true
-                    serverTask = Task {
-                        do {
-                            if server == nil {
-                                server = SKKServer(version: "0.1.0", logger: logger)
-                                server?.prepare()
-                            }
-                            try await server!.run(host: host, port: port, incomingCharset: incomingCharset.stringEncoding)
-                        } catch is CancellationError {
-                            // キャンセルが正常に完了した
-                            logger.notice("Server task was cancelled.")
-                        } catch {
-                            // キャンセル以外のエラーが発生した場合はアラートを表示する
-                            logger.error("Server task error: \(error)")
-                            errorMessage = error.localizedDescription
-                            showingAlert = true
-                        }
-                        running = false
-                        serverTask = nil
-                    }
+                    startServer()
                 }
                 .disabled(running)
                 Button("Stop Server") {
@@ -64,10 +47,38 @@ struct ContentView: View {
             }
         }
         .padding()
+        .onAppear {
+            if startServerAtLaunch {
+                startServer()
+            }
+        }
         .alert("Error", isPresented: $showingAlert) {
             Button("OK") { }
         } message: {
             Text(errorMessage)
+        }
+    }
+
+    func startServer() {
+        running = true
+        serverTask = Task {
+            do {
+                if server == nil {
+                    server = SKKServer(version: "0.1.0", logger: logger)
+                    server?.prepare()
+                }
+                try await server!.run(host: host, port: port, incomingCharset: incomingCharset.stringEncoding)
+            } catch is CancellationError {
+                // キャンセルが正常に完了した
+                logger.notice("Server task was cancelled.")
+            } catch {
+                // キャンセル以外のエラーが発生した場合はアラートを表示する
+                logger.error("Server task error: \(error)")
+                errorMessage = error.localizedDescription
+                showingAlert = true
+            }
+            running = false
+            serverTask = nil
         }
     }
 }

--- a/App/azoo-key-skkserv/azoo_key_skkservApp.swift
+++ b/App/azoo-key-skkserv/azoo_key_skkservApp.swift
@@ -15,5 +15,6 @@ struct azoo_key_skkservApp: App {
             ContentView()
                 .frame(width: 320, height: 180)
         }
+        .windowResizability(.contentSize)
     }
 }


### PR DESCRIPTION
macOSアプリ部分に次の修正を入れます。

- ウィンドウリサイズを無効化します https://github.com/gitusp/azoo-key-skkserv/commit/394d1fbe13553c0e289c6c140f09f7a48ad3b467
- SKKServerの初期化をメインスレッドでやるとアプリ起動時に固まるので、Start Serverボタンを押したときに非同期で実行するようにします https://github.com/gitusp/azoo-key-skkserv/commit/6d24b5b2302165556bce6be6bdf244c99ad3b4b0
- ホスト、ポート、入力文字コード設定をPreferencesに保存するようにします https://github.com/gitusp/azoo-key-skkserv/commit/407960187dc2893309d93a277ccd9332c614dcbf
- Apple Notarizationに必要なHardened Runtimeを有効にします https://github.com/gitusp/azoo-key-skkserv/pull/16/commits/8997bbab3d902933d6ae7fb4939e566a3e7586b9
- xcodeprojのSwift Versionの設定がデフォルトのSwift 5になってたのをSPM側に合わせてSwift 6に変更 https://github.com/gitusp/azoo-key-skkserv/pull/16/commits/912c3620b3a3d20f0ccee6d56916e567e01bd16f
- アプリ起動時に自動でサーバーを起動するフラグをPreferencesに保存するようにします https://github.com/gitusp/azoo-key-skkserv/pull/16/commits/9dea565beefa2482d259b16d152bef36cdd4e6c1

<img width="320" height="208" alt="image" src="https://github.com/user-attachments/assets/9c3a919a-56e5-4473-9f5a-eb569345b513" />


保存したPreferencesは通常の `~/Library/Preferences` 内ではなく、Sandbox用の `~/Library/Containers/io.github.gitusp.azoo-key-skkserv/Data/Library/Preferences/io.github.gitusp.azoo-key-skkserv.plist` に記録されます。

<img width="627" height="350" alt="image" src="https://github.com/user-attachments/assets/0370ce42-781e-495f-8d47-2a9932c0f555" />
