### PR TITLE
chore: use CFBundleShortVersionString

### DIFF
--- a/App/azoo-key-skkserv/ContentView.swift
+++ b/App/azoo-key-skkserv/ContentView.swift
@@ -64,7 +64,8 @@ struct ContentView: View {
         serverTask = Task {
             do {
                 if server == nil {
-                    server = SKKServer(version: "0.1.0", logger: logger)
+                    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+                    server = SKKServer(version: version, logger: logger)
                     server?.prepare()
                 }
                 try await server!.run(host: host, port: port, incomingCharset: incomingCharset.stringEncoding)


### PR DESCRIPTION
GUI版でSKKServerコンストラクタに渡す引数のversionを固定値の"0.1.0"にしていたのをアプリのバージョンを採用するようにします。
(CFBundleShortVersionStringは "0.2.0" のような文字列です)