### PR TITLE
feat: add inferenceLimit option

### DIFF
--- a/App/azoo-key-skkserv/ContentView.swift
+++ b/App/azoo-key-skkserv/ContentView.swift
@@ -9,6 +9,7 @@ struct ContentView: View {
     @AppStorage("port") var port: Int = 1178
     @AppStorage("incomingCharset") var incomingCharset: IncomingCharset = .utf8
     @AppStorage("startServerAtLaunch") var startServerAtLaunch: Bool = false
+    @AppStorage("inferenceLimit") var inferenceLimit: Int = 3
     @State var running: Bool = false
     @State var serverTask: Task<Void, Error>? = nil
     @State var showingAlert: Bool = false
@@ -28,6 +29,8 @@ struct ContentView: View {
                 TextField("Host", text: $host, prompt: Text("127.0.0.1"))
                     .disabled(running)
                 TextField("Port", value: $port, formatter: formatter, prompt: Text("1178"))
+                    .disabled(running)
+                TextField("Inference Limit", value: $inferenceLimit, formatter: formatter, prompt: Text("1"))
                     .disabled(running)
                 Picker("Incoming Charset", selection: $incomingCharset) {
                     ForEach(IncomingCharset.allCases, id: \.self) { charset in
@@ -68,7 +71,7 @@ struct ContentView: View {
                     server = SKKServer(version: version, logger: logger)
                     server?.prepare()
                 }
-                try await server!.run(host: host, port: port, incomingCharset: incomingCharset.stringEncoding)
+                try await server!.run(host: host, port: port, incomingCharset: incomingCharset.stringEncoding, inferenceLimit: inferenceLimit)
             } catch is CancellationError {
                 // キャンセルが正常に完了した
                 logger.notice("Server task was cancelled.")
@@ -86,5 +89,5 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
-        .frame(width: 320, height: 180)
+        .frame(width: 320, height: 220)
 }

--- a/App/azoo-key-skkserv/azoo_key_skkservApp.swift
+++ b/App/azoo-key-skkserv/azoo_key_skkservApp.swift
@@ -13,7 +13,7 @@ struct azoo_key_skkservApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .frame(width: 320, height: 180)
+                .frame(width: 320, height: 220)
         }
         .windowResizability(.contentSize)
     }

--- a/Core/Sources/Core/SKKServer.swift
+++ b/Core/Sources/Core/SKKServer.swift
@@ -6,9 +6,35 @@ import NIOPosix
 import KanaKanjiConverterModuleWithDefaultDictionary
 import Logging
 
+private func createZenzaiMode(inferenceLimit: Int) -> ConvertRequestOptions.ZenzaiMode {
+    return .on(
+        weight: Bundle.module.url(forResource: "zenz-v1", withExtension: "gguf")!,
+        inferenceLimit: inferenceLimit,
+        personalizationMode: nil,
+        versionDependentMode: .v1
+    )
+}
+
+private func createConvertOption(inferenceLimit: Int, version: String) -> ConvertRequestOptions {
+    return ConvertRequestOptions.withDefaultDictionary(
+        // 日本語予測変換
+        requireJapanesePrediction: false,
+        // 英語予測変換
+        requireEnglishPrediction: false,
+        // 入力言語
+        keyboardLanguage: .ja_JP,
+        // 学習タイプ
+        learningType: .nothing,
+        // TODO: 扱いについて検討
+        memoryDirectoryURL: URL(fileURLWithPath: ""),
+        sharedContainerURL: URL(fileURLWithPath: ""),
+        zenzaiMode: createZenzaiMode(inferenceLimit: inferenceLimit),
+        metadata: .init(versionString: version)
+    )
+}
+
 @MainActor public struct SKKServer {
     let allocator = ByteBufferAllocator()
-    let convertOption: ConvertRequestOptions
     let converter: KanaKanjiConverter
     let version: String
     let logger: Logger
@@ -16,26 +42,7 @@ import Logging
     public init(version: String, logger: Logger) {
         self.version = version
         self.logger = logger
-        convertOption = ConvertRequestOptions.withDefaultDictionary(
-            // 日本語予測変換
-            requireJapanesePrediction: false,
-            // 英語予測変換
-            requireEnglishPrediction: false,
-            // 入力言語
-            keyboardLanguage: .ja_JP,
-            // 学習タイプ
-            learningType: .nothing,
-            // TODO: 扱いについて検討
-            memoryDirectoryURL: URL(fileURLWithPath: ""),
-            sharedContainerURL: URL(fileURLWithPath: ""),
-            zenzaiMode: .on(
-                weight: Bundle.module.url(forResource: "zenz-v1", withExtension: "gguf")!,
-                inferenceLimit: 1,
-                personalizationMode: nil,
-                versionDependentMode: .v1
-            ),
-            metadata: .init(versionString: version)
-        )
+        let convertOption = createConvertOption(inferenceLimit: 1, version: version)
         // コンバータ初期化
         converter = KanaKanjiConverter(dicdataStore: DicdataStore(convertRequestOptions: convertOption))
     }
@@ -44,6 +51,7 @@ import Logging
         // HACK: ダミーリクエストを送信してモデルを先読みしておく
         var dummyComposingText = ComposingText()
         dummyComposingText.insertAtCursorPosition("もでるさきよみ", inputStyle: .direct)
+        let convertOption = createConvertOption(inferenceLimit: 1, version: version)
         _ = converter.requestCandidates(dummyComposingText, options: convertOption)
     }
 
@@ -67,7 +75,9 @@ import Logging
       * task.cancel()
       * ```
       */
-    public func run(host: String = "127.0.0.1", port: Int = 1178, incomingCharset: String.Encoding = .utf8) async throws {
+    public func run(host: String = "127.0.0.1", port: Int = 1178, incomingCharset: String.Encoding = .utf8, inferenceLimit: Int = 1) async throws {
+        let convertOption = createConvertOption(inferenceLimit: inferenceLimit, version: version)
+        
         // こちらのガイドを参考に実装した。
         // https://swiftonserver.com/using-swiftnio-channels/
         let server = try await ServerBootstrap(group: NIOSingletons.posixEventLoopGroup)
@@ -92,14 +102,14 @@ import Logging
             try await server.executeThenClose { clients in
                 for try await client in clients {
                     group.addTask {
-                        await handleClient(client: client, host: host, port: port, incomingCharset: incomingCharset)
+                        await handleClient(client: client, host: host, port: port, incomingCharset: incomingCharset, convertOption: convertOption)
                     }
                 }
             }
         }
     }
 
-    func handleClient(client: NIOAsyncChannel<ByteBuffer, ByteBuffer>, host: String, port: Int, incomingCharset: String.Encoding) async {
+    func handleClient(client: NIOAsyncChannel<ByteBuffer, ByteBuffer>, host: String, port: Int, incomingCharset: String.Encoding, convertOption: ConvertRequestOptions) async {
         // クライアントが先にソケットを閉じている状態でソケットへの書き込みを行ったりすると例外が発生し、
         // そのあとの接続でinboundMessagesからメッセージが取得できなくなってしまう。
         // それを防ぐため例外をキャッチする必要がある。

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ macOS版はGUIアプリケーションの提供もございます。([mtgto](htt
 ## 使い方
 
 ```sh
-azoo-key-skkserv [--port <port-number>] [--incoming-charset <charset>] [--help] [--version]
+azoo-key-skkserv [--port <port-number>] [--incoming-charset <charset>] [--inference-limit <limit>] [--help] [--version]
 ```
 
 _EUC-JP範囲外の候補があるため `--outgoing-charset` オプションはなく、サーバーからは常にUTF-8で返します。_

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -20,6 +20,9 @@ struct AzooKeySkkserv: ParsableCommand {
     @Option(help: "The expected incoming character set.")
     var incomingCharset: IncomingCharset = .utf8
 
+    @Option(help: "Maximum number of inferences for AI-based conversion.")
+    var inferenceLimit: Int = 3
+
     func run() throws {
         Task {
             do {
@@ -56,5 +59,5 @@ enum IncomingCharset: String, ExpressibleByArgument, CaseIterable {
 func runServer(context: AzooKeySkkserv) async throws {
     let server = await SKKServer(version: version, logger: logger)
     await server.prepare()
-    try await server.run(host: "127.0.0.1", port: context.port, incomingCharset: context.incomingCharset.stringEncoding)
+    try await server.run(host: "127.0.0.1", port: context.port, incomingCharset: context.incomingCharset.stringEncoding, inferenceLimit: context.inferenceLimit)
 }

--- a/Tests/CoreTests/SKKServerVersionTest.swift
+++ b/Tests/CoreTests/SKKServerVersionTest.swift
@@ -15,7 +15,7 @@ struct SKKServerVersionTest {
         await server.prepare()
 
         let serverTask = Task {
-            try await server.run(host: "127.0.0.1", port: port, incomingCharset: String.Encoding.utf8)
+            try await server.run(host: "127.0.0.1", port: port, incomingCharset: String.Encoding.utf8, inferenceLimit: 1)
         }
 
         // サーバーが起動するまで少し待つ


### PR DESCRIPTION
ある程度の長文を変換するにあたって, 推論回数が1固定なのは少ないケースが多い可能性があるため, 一旦設定可能な状態にしました.
関連: https://github.com/gitusp/azoo-key-skkserv/issues/22