### PR TITLE
chore: bump AzooKeyKanaKanjiConverter version to 0.11.1

### DIFF
--- a/App/azoo-key-skkserv.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/azoo-key-skkserv.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/azooKey/AzooKeyKanaKanjiConverter",
       "state" : {
-        "revision" : "2cde22d3e2dd67244f7b095e092f23892dd4d566"
+        "revision" : "75c7c2b9c517610d27be23ac47b0a54ccb4de76d",
+        "version" : "0.11.1"
       }
     },
     {
@@ -95,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ensan-hcl/swift-tokenizers",
       "state" : {
-        "branch" : "feat/minimum",
-        "revision" : "407e51806c0c3354a9045f23859ed1704114e514"
+        "revision" : "4a606f66e0cc4d7d9f0197649e812f7fc86a4c34",
+        "version" : "0.0.1"
       }
     },
     {
@@ -104,7 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ensan-hcl/SwiftyMarisa",
       "state" : {
-        "revision" : "6e145aef5583aac96dd7ff8f9fbb9944d893128e"
+        "revision" : "91acc3cb0e747e0bd4b0e0813d42fb273d10e62f",
+        "version" : "0.0.1"
       }
     }
   ],

--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", revision: "2cde22d3e2dd67244f7b095e092f23892dd4d566", traits: ["Zenzai"]),
+        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", from: "0.11.1", traits: ["Zenzai"]),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],

--- a/Core/Sources/Core/SKKServer.swift
+++ b/Core/Sources/Core/SKKServer.swift
@@ -44,7 +44,6 @@ private func createConvertOption(inferenceLimit: Int, version: String) -> Conver
     public init(version: String, logger: Logger) {
         self.version = version
         self.logger = logger
-        let convertOption = createConvertOption(inferenceLimit: 1, version: version)
         // コンバータ初期化
         converter = KanaKanjiConverter.withDefaultDictionary()
     }

--- a/Core/Sources/Core/SKKServer.swift
+++ b/Core/Sources/Core/SKKServer.swift
@@ -16,7 +16,7 @@ private func createZenzaiMode(inferenceLimit: Int) -> ConvertRequestOptions.Zenz
 }
 
 private func createConvertOption(inferenceLimit: Int, version: String) -> ConvertRequestOptions {
-    return ConvertRequestOptions.withDefaultDictionary(
+    return ConvertRequestOptions(
         // 日本語予測変換
         requireJapanesePrediction: false,
         // 英語予測変換
@@ -28,6 +28,8 @@ private func createConvertOption(inferenceLimit: Int, version: String) -> Conver
         // TODO: 扱いについて検討
         memoryDirectoryURL: URL(fileURLWithPath: ""),
         sharedContainerURL: URL(fileURLWithPath: ""),
+        textReplacer: .withDefaultEmojiDictionary(),
+        specialCandidateProviders: KanaKanjiConverter.defaultSpecialCandidateProviders,
         zenzaiMode: createZenzaiMode(inferenceLimit: inferenceLimit),
         metadata: .init(versionString: version)
     )
@@ -44,7 +46,7 @@ private func createConvertOption(inferenceLimit: Int, version: String) -> Conver
         self.logger = logger
         let convertOption = createConvertOption(inferenceLimit: 1, version: version)
         // コンバータ初期化
-        converter = KanaKanjiConverter(dicdataStore: DicdataStore(convertRequestOptions: convertOption))
+        converter = KanaKanjiConverter.withDefaultDictionary()
     }
 
     public func prepare() {
@@ -135,7 +137,7 @@ private func createConvertOption(inferenceLimit: Int, version: String) -> Conver
                             : "1/"
                             + results.mainResults
                             // 読み全文に対応するもの以外・読みと完全一致するものは除去
-                                .filter({ result in result.correspondingCount == yomi.count && result.text != yomi })
+                                .filter({ result in result.rubyCount == yomi.count && result.text != yomi })
                                 .map({ result in result.text })
                                 .joined(by: "/")
                             + "/\n"


### PR DESCRIPTION
AzooKeyKanaKanjiConverterのバージョンをv[0.11.1](https://github.com/azooKey/AzooKeyKanaKanjiConverter/releases/tag/v0.11.1)に上げます。
https://github.com/azooKey/AzooKeyKanaKanjiConverter/issues/259 での動作確認でコンパイルを通すように手元で新APIに対応していたので、それをPRにしました。

これにより含まれるリソースファイルに濁点・半濁点のファイルがなくなり、Finderでコピーしても壊れることがなくなると思います。

AzooKeyKanaKanjiConverterのAPIが大きく変更されているため、対応したつもりですがそのあたりを見ていただければと思います。